### PR TITLE
feat(DP-841): allow TextField prop overrides

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -6,13 +6,26 @@ import {
   IconButton,
   CircularProgress,
   Paper,
-  BoxProps,
 } from "@mui/material";
+import type { BoxProps, TextFieldProps } from "@mui/material";
 import ClearIcon from "@mui/icons-material/Clear";
 import { useDebounce } from "../../hooks/useDebounce";
 import { isMacPlatform } from "../../utils/keyboard";
 
-export interface SearchBarProps {
+type SearchBarTextFieldProps = Omit<
+  TextFieldProps,
+  | "autoFocus"
+  | "defaultValue"
+  | "id"
+  | "name"
+  | "onChange"
+  | "onKeyDown"
+  | "placeholder"
+  | "size"
+  | "value"
+>;
+
+export type SearchBarProps = SearchBarTextFieldProps & {
   value?: string;
   defaultValue?: string;
   onChange?: (value: string) => void;
@@ -30,7 +43,7 @@ export interface SearchBarProps {
   shortcut?: boolean;
   id?: string;
   name?: string;
-}
+};
 
 export function SearchBar({
   value,
@@ -50,6 +63,7 @@ export function SearchBar({
   shortcut = true,
   id,
   name,
+  ...textFieldProps
 }: SearchBarProps) {
   const [internal, setInternal] = React.useState(defaultValue ?? "");
   const isControlled = value !== undefined;
@@ -152,6 +166,7 @@ export function SearchBar({
               ),
             },
           }}
+          {...textFieldProps}
         />
         {actions}
       </Paper>

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -17,7 +17,6 @@ type SearchBarTextFieldProps = Omit<
   | "autoFocus"
   | "defaultValue"
   | "id"
-  | "inputRef"
   | "name"
   | "onChange"
   | "onKeyDown"
@@ -69,6 +68,7 @@ export function SearchBar({
   boxSx,
   shortcut = true,
   id,
+  inputRef,
   name,
   ...textFieldProps
 }: SearchBarProps) {
@@ -77,8 +77,23 @@ export function SearchBar({
   const isControlled = value !== undefined;
   const val = isControlled ? value! : internal;
 
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const internalInputRef = React.useRef<HTMLInputElement>(null);
   const debounced = useDebounce(val, debounceMs);
+
+  const setInputRef = React.useCallback(
+    (node: HTMLInputElement | null) => {
+      // Update the internal ref (used for focusing and other internal logic)
+      internalInputRef.current = node;
+
+      // Update the external ref passed in props, supporting both callback refs and mutable ref objects
+      if (typeof inputRef === "function") {
+        inputRef(node);
+      } else if (inputRef) {
+        inputRef.current = node;
+      }
+    },
+    [inputRef],
+  );
 
   const stop = (e: React.SyntheticEvent) => {
     e.stopPropagation();
@@ -96,7 +111,7 @@ export function SearchBar({
         (!isMacPlatform() && e.ctrlKey && e.key.toLowerCase() === "k")
       ) {
         e.preventDefault();
-        inputRef.current?.focus();
+        internalInputRef.current?.focus();
       }
     };
     window.addEventListener("keydown", handler);
@@ -113,7 +128,7 @@ export function SearchBar({
     if (!isControlled) setInternal("");
     onChange?.("");
     onSearch?.("");
-    inputRef.current?.focus();
+    internalInputRef.current?.focus();
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -179,7 +194,7 @@ export function SearchBar({
           id={id}
           name={name}
           fullWidth
-          inputRef={inputRef}
+          inputRef={setInputRef}
           autoFocus={autoFocus}
           size={size}
           value={val}

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -17,6 +17,7 @@ type SearchBarTextFieldProps = Omit<
   | "autoFocus"
   | "defaultValue"
   | "id"
+  | "inputRef"
   | "name"
   | "onChange"
   | "onKeyDown"
@@ -24,6 +25,12 @@ type SearchBarTextFieldProps = Omit<
   | "size"
   | "value"
 >;
+
+type TextFieldSlotProps = NonNullable<TextFieldProps["slotProps"]>;
+type TextFieldInputSlotProps = NonNullable<TextFieldSlotProps["input"]>;
+type TextFieldInputSlotOwnerState = Parameters<
+  Extract<TextFieldInputSlotProps, (...args: never[]) => unknown>
+>[0];
 
 export type SearchBarProps = SearchBarTextFieldProps & {
   value?: string;
@@ -65,6 +72,7 @@ export function SearchBar({
   name,
   ...textFieldProps
 }: SearchBarProps) {
+  const { slotProps, ...restTextFieldProps } = textFieldProps;
   const [internal, setInternal] = React.useState(defaultValue ?? "");
   const isControlled = value !== undefined;
   const val = isControlled ? value! : internal;
@@ -113,6 +121,43 @@ export function SearchBar({
     if (e.key === "Escape" && !disableClear && val) handleClear();
   };
 
+  const searchAdornment = (
+    <InputAdornment position="end">
+      {loading ? (
+        <CircularProgress size={size === "small" ? 16 : 18} />
+      ) : (
+        !disableClear &&
+        val && (
+          <IconButton
+            aria-label="Clear search"
+            onClick={handleClear}
+            edge="end"
+            size={size === "small" ? "small" : "medium"}
+          >
+            <ClearIcon fontSize={size === "small" ? "small" : "medium"} />
+          </IconButton>
+        )
+      )}
+    </InputAdornment>
+  );
+
+  const inputSlotProps = (ownerState: TextFieldInputSlotOwnerState) => {
+    const resolvedInputSlotProps =
+      typeof slotProps?.input === "function"
+        ? slotProps.input(ownerState)
+        : slotProps?.input;
+
+    return {
+      ...resolvedInputSlotProps,
+      endAdornment: (
+        <>
+          {resolvedInputSlotProps?.endAdornment}
+          {searchAdornment}
+        </>
+      ),
+    };
+  };
+
   return (
     <Box {...boxSx} sx={boxSx?.sx} onClick={stop}>
       <Paper
@@ -130,6 +175,7 @@ export function SearchBar({
         })}
       >
         <TextField
+          {...restTextFieldProps}
           id={id}
           name={name}
           fullWidth
@@ -142,31 +188,9 @@ export function SearchBar({
           onKeyDown={handleKeyDown}
           variant="outlined"
           slotProps={{
-            input: {
-              endAdornment: (
-                <InputAdornment position="end">
-                  {loading ? (
-                    <CircularProgress size={size === "small" ? 16 : 18} />
-                  ) : (
-                    !disableClear &&
-                    val && (
-                      <IconButton
-                        aria-label="Clear search"
-                        onClick={handleClear}
-                        edge="end"
-                        size={size === "small" ? "small" : "medium"}
-                      >
-                        <ClearIcon
-                          fontSize={size === "small" ? "small" : "medium"}
-                        />
-                      </IconButton>
-                    )
-                  )}
-                </InputAdornment>
-              ),
-            },
+            ...slotProps,
+            input: inputSlotProps,
           }}
-          {...textFieldProps}
         />
         {actions}
       </Paper>


### PR DESCRIPTION
## Summary

Update `SearchBar` so consumers can pass additional MUI `TextField` props through to the internal `TextField`, while keeping the existing SearchBar-specific API.

The prop types are merged by starting from MUI's `TextFieldProps` and removing the props that `SearchBar` already controls, such as `value`, `onChange`, `placeholder`, and `size`. `Omit` is used here so those SearchBar-specific props do not conflict with MUI's original `TextField` prop definitions. This is especially important for `onChange`, because `SearchBar` exposes a simplified callback that returns the input string, while MUI's `TextField` receives the raw change event.

## Jira

https://hdruk.atlassian.net/browse/DP-841

## PR Type

- [X] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [X] `npm run build` passes
- [X] Verified locally in CDS via `npx yalc publish --push`

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [X] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<img width="305" height="274" alt="Screenshot 2026-05-21 at 12 22 53" src="https://github.com/user-attachments/assets/98cae0cb-5da3-4984-a12d-916f2f0f19cd" />
<img width="744" height="357" alt="Screenshot 2026-05-21 at 12 24 18" src="https://github.com/user-attachments/assets/e5cbbc4e-35ae-4def-b69c-ba6b2cca1450" />

## Risk and Rollback

- Risk level: low
- Main risk areas:
  - Consumers can now override internal `TextField` props such as `slotProps` or `inputRef`, which could affect SearchBar internals if used incorrectly.
- Rollback plan:
  - Revert this PR and release the previous package version.

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->