### PR TITLE
fix(DP-860): Update SearchBar's clear input icon

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -8,7 +8,7 @@ import {
   Paper,
 } from "@mui/material";
 import type { BoxProps, TextFieldProps } from "@mui/material";
-import ClearIcon from "@mui/icons-material/Clear";
+import CancelIcon from "@mui/icons-material/Cancel";
 import { useDebounce } from "../../hooks/useDebounce";
 import { isMacPlatform } from "../../utils/keyboard";
 
@@ -149,7 +149,7 @@ export function SearchBar({
             edge="end"
             size={size === "small" ? "small" : "medium"}
           >
-            <ClearIcon fontSize={size === "small" ? "small" : "medium"} />
+            <CancelIcon fontSize={size === "small" ? "small" : "medium"} />
           </IconButton>
         )
       )}


### PR DESCRIPTION
## Summary

This updates the search bar component input's clear icon from MUI's "Clear" to "Cancel" to match the new Figma design.

Something to note is that there seems to be some difference in the naming convention between the Figma and MUI icons.

In Figma and the ticket this icon is being referred to as "Clear", but its corresponding MUI icon seems to be called "Cancel".

And the actual MUI "Clear" icon is just an "X" without a circle fill and seems to correspond to the Figma design's "Close" icon.

This might be temporary change until we switch to Material Symbols.

## Jira

https://hdruk.atlassian.net/browse/DP-860

This is subtask from the following ticket:
https://hdruk.atlassian.net/browse/DP-721

## PR Type

- [ ] `feat`
- [X] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Screenshots / Evidence

## Before:
<img width="1049" height="166" alt="Screenshot 2026-06-11 at 15 06 27" src="https://github.com/user-attachments/assets/51f943ce-869c-40f7-8fb8-7b474dd83cf5" />

## After:
<img width="1044" height="170" alt="Screenshot 2026-06-11 at 15 26 44" src="https://github.com/user-attachments/assets/b3d65aee-9622-40db-940d-e7f91e7b7000" />

<!---
## Figma:
<img width="816" height="253" alt="Screenshot 2026-06-11 at 15 08 07" src="https://github.com/user-attachments/assets/d7f191fc-724c-4194-b9c1-a5cc804e5003" />
-->